### PR TITLE
Feature/add maml meta test

### DIFF
--- a/src/maml/algorithm/buffer.py
+++ b/src/maml/algorithm/buffer.py
@@ -49,7 +49,7 @@ class Buffer:  # pylint: disable=too-many-instance-attributes
         self._top += 1
 
     def add_trajs(self, trajs):
-        """Add trajectories to buffer"""
+        """Add trajectories to the buffer"""
         for traj in trajs:
             for (obs, action, reward, next_obs, done, value, log_prob) in zip(
                 traj["cur_obs"],

--- a/src/maml/algorithm/buffer.py
+++ b/src/maml/algorithm/buffer.py
@@ -13,13 +13,16 @@ class MultiBuffer:
         self,
         observ_dim,
         action_dim,
-        num_buffers,
+        num_tasks,
+        num_episodes,
         max_size,
         device,
     ):
-        self.num_buffers = num_buffers
+        self.num_episodes = num_episodes
+        self.num_tasks = num_tasks
+        self.num_buffers = num_tasks * num_episodes
         self.multi_buffers = {}
-        for i in range(num_buffers):
+        for i in range(self.num_buffers):
             self.multi_buffers[i] = Buffer(
                 observ_dim=observ_dim,
                 action_dim=action_dim,
@@ -29,12 +32,12 @@ class MultiBuffer:
 
     def add_trajs(self, cur_task, cur_adapt, trajs):
         """Add trajectories to the sub-buffer of multi-buffer"""
-        buffer_index = cur_adapt * self.num_buffers + cur_task
+        buffer_index = self.num_tasks * cur_adapt + cur_task
         self.multi_buffers[buffer_index].add_trajs(trajs)
 
     def get_samples(self, cur_task, cur_adapt):
         """Sample batch of the sub-buffer in multi-buffer"""
-        buffer_index = cur_adapt * self.num_buffers + cur_task
+        buffer_index = self.num_tasks * cur_adapt + cur_task
         batch = self.multi_buffers[buffer_index].get_samples()
         return batch
 
@@ -54,7 +57,6 @@ class Buffer:  # pylint: disable=too-many-instance-attributes
         max_size,
         device,
         gamma=0.99,
-        lamda=0.97,
     ):
 
         self._cur_obs = np.zeros((max_size, observ_dim))
@@ -64,17 +66,15 @@ class Buffer:  # pylint: disable=too-many-instance-attributes
         self._dones = np.zeros((max_size, 1), dtype="uint8")
         self._returns = np.zeros((max_size, 1))
         self._advants = np.zeros((max_size, 1))
-        self._values = np.zeros((max_size, 1))
         self._log_probs = np.zeros((max_size, 1))
         self.device = device
         self.gamma = gamma
-        self.lamda = lamda
 
         self._max_size = max_size
         self._top = 0
 
     # pylint: disable=too-many-arguments
-    def add(self, obs, action, reward, next_obs, done, value, log_prob):
+    def add(self, obs, action, reward, next_obs, done, log_prob):
         """Add transition, value, and log_prob to buffer"""
         assert self._top < self._max_size
         self._cur_obs[self._top] = obs
@@ -82,58 +82,65 @@ class Buffer:  # pylint: disable=too-many-instance-attributes
         self._rewards[self._top] = reward
         self._next_obs[self._top] = next_obs
         self._dones[self._top] = done
-        self._values[self._top] = value
         self._log_probs[self._top] = log_prob
         self._top += 1
 
     def add_trajs(self, trajs):
         """Add trajectories to the buffer"""
         for traj in trajs:
-            for (obs, action, reward, next_obs, done, value, log_prob) in zip(
+            for (obs, action, reward, next_obs, done, log_prob) in zip(
                 traj["cur_obs"],
                 traj["actions"],
                 traj["rewards"],
                 traj["next_obs"],
                 traj["dones"],
-                traj["values"],
                 traj["log_probs"],
             ):
-                self.add(obs, action, reward, next_obs, done, value, log_prob)
+                self.add(obs, action, reward, next_obs, done, log_prob)
 
-    def compute_gae(self):
-        """Compute return and GAE"""
-        prev_value = 0
+    def compute_return(self):
+        """Compute return"""
         running_return = 0
-        running_advant = 0
 
         for t in reversed(range(0, len(self._rewards))):
             # Compute return
             running_return = self._rewards[t] + self.gamma * (1 - self._dones[t]) * running_return
             self._returns[t] = running_return
 
+    @staticmethod
+    def compute_gae(rewards, dones, values):
+        """Compute GAE"""
+        gamma = 0.99
+        lamda = 1
+        prev_value = 0
+        running_advant = 0
+        rewards = rewards.numpy()
+        dones = dones.numpy()
+        values = values.numpy()
+        advants = np.zeros_like(rewards)
+
+        for t in reversed(range(0, len(rewards))):
             # Compute GAE
-            running_tderror = (
-                self._rewards[t] + self.gamma * (1 - self._dones[t]) * prev_value - self._values[t]
-            )
-            running_advant = (
-                running_tderror + self.gamma * self.lamda * (1 - self._dones[t]) * running_advant
-            )
-            self._advants[t] = running_advant
-            prev_value = self._values[t]
+            running_tderror = rewards[t] + gamma * (1 - dones[t]) * prev_value - values[t]
+            running_advant = running_tderror + gamma * lamda * (1 - dones[t]) * running_advant
+            advants[t] = running_advant
+            prev_value = values[t]
 
         # Normalize advantage
-        self._advants = (self._advants - self._advants.mean()) / self._advants.std()
+        advants = (advants - advants.mean()) / advants.std()
+        return torch.Tensor(advants)
 
     def get_samples(self):
         """Get sample batch in buffer"""
         assert self._top == self._max_size
 
-        self.compute_gae()
+        self.compute_return()
         batch = dict(
             obs=self._cur_obs,
             actions=self._actions,
+            rewards=self._rewards,
+            dones=self._dones,
             returns=self._returns,
-            advants=self._advants,
             log_probs=self._log_probs,
         )
         return {key: torch.Tensor(value).to(self.device) for key, value in batch.items()}

--- a/src/maml/algorithm/meta_learner.py
+++ b/src/maml/algorithm/meta_learner.py
@@ -5,14 +5,15 @@ Meta-train and meta-test codes with MAML algorithm
 
 import datetime
 import os
+import time
 
 import higher
 import numpy as np
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
-from maml.algorithm.buffer import Buffer
-from maml.algorithm.sampler import Sampler
+from src.maml.algorithm.buffer import Buffer
+from src.maml.algorithm.sampler import Sampler
 
 
 class MetaLearner:  # pylint: disable=too-many-instance-attributes
@@ -45,8 +46,8 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
         self.max_step = config["max_step"]
         self.test_samples = config["test_samples"]
 
-        self.inner_adaptation_steps = config["inner_adaptation_steps"]
-        self.meta_grad_iters = config["maml_optimizer_steps"]
+        self.inner_grad_iters = config["inner_grad_iters"]
+        self.outer_grad_iters = config["outer_grad_iters"]
 
         self.sampler = Sampler(
             env=env,
@@ -55,7 +56,7 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
             device=device,
         )
 
-        self.meta_buffer = Buffer(
+        self.outer_buffer = Buffer(
             observ_dim=observ_dim,
             action_dim=action_dim,
             max_size=self.train_samples * self.num_sample_tasks,
@@ -68,11 +69,11 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
             device=device,
         )
 
-        self.meta_optimizer = torch.optim.Adam(
+        self.outer_optimizer = torch.optim.Adam(
             list(self.agent.policy.parameters()),
             lr=config["learning_rate"],
         )
-        self.inner_optimizer = torch.optim.SGD(
+        self.inner_optimizer_base = torch.optim.SGD(
             list(self.agent.policy.parameters()),
             lr=config["inner_learning_rate"],
         )
@@ -88,26 +89,34 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
             )
         )
 
+    # pylint: disable=too-many-locals
     def meta_train(self):
         """MAML meta-training"""
+        total_start_time = time.time()
         for iteration in range(self.train_iters):
+            start_time = time.time()
+            inner_policy_loss_sum = 0
+            outer_policy_loss_sum = 0
+            value_loss_sum = 0
 
-            print("=============== Iteration {} ===============".format(iteration))
+            print(f"=============== Iteration {iteration} ===============")
             # Sample tasks randomly from train tasks distribution.
-            for _ in range(self.num_sample_tasks):
+            for i in range(self.num_sample_tasks):
                 index = np.random.randint(len(self.train_tasks))
                 self.env.reset_task(index)
                 self.agent.policy.is_deterministic = False
-                print("[{0}/{1}] collecting losses".format(index + 1, len(self.train_tasks)))
+                print(f"[{i+1}/{self.num_sample_tasks}] collecting inner-loop losses")
 
-                # Branch policy and optimizer
+                # Branch policy network and its optimizer by Higher
                 with higher.innerloop_ctx(
                     self.agent.policy,
-                    self.inner_optimizer,
+                    self.inner_optimizer_base,
                     copy_initial_weights=False,
-                ) as (inner_policy, branch_optimizer):
+                ) as (inner_policy, inner_optimizer_branch):
 
-                    for _ in range(self.inner_adaptation_steps):
+                    inner_policy.is_deterministic = False
+                    # Adapt meta-policy to each task with n-steps grandients
+                    for _ in range(self.inner_grad_iters):
                         # Sample trajectory with inner policy
                         trajs = self.sampler.obtain_trajs(
                             inner_policy,
@@ -115,37 +124,156 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
                             max_step=self.max_step,
                         )
                         self.inner_buffer.add_trajs(trajs)
-                        print("inner_buffer")
                         batch = self.inner_buffer.get_samples()
                         # Inner update
-                        ppo_loss = self.agent.compute_losses(inner_policy, batch)
-                        branch_optimizer.step(ppo_loss)
+                        inner_policy_loss, value_loss = self.agent.compute_losses(inner_policy, batch)
+                        inner_optimizer_branch.step(inner_policy_loss)
+
+                        inner_policy_loss_sum += inner_policy_loss
+                        value_loss_sum += value_loss
 
                     # Sample trajectory with adapted policy
-                    inner_policy.is_deterministic = False
                     trajs = self.sampler.obtain_trajs(
                         inner_policy,
                         max_samples=self.train_samples,
                         max_step=self.max_step,
                     )
-                    self.meta_buffer.add_trajs(trajs)
+                    self.outer_buffer.add_trajs(trajs)
 
             # Meta update
-            print("meta_buffer")
-            batch = self.meta_buffer.get_samples()
-            for _ in range(self.meta_grad_iters):
-                meta_loss = self.agent.compute_losses(self.agent.policy, batch)
-                self.meta_optimizer.zero_grad()
-                meta_loss.backward()
-                self.meta_optimizer.step()
+            print("Meta-updating outer-loop policy")
+            batch = self.outer_buffer.get_samples()
+            for _ in range(self.outer_grad_iters):
+                outer_policy_loss, value_loss = self.agent.compute_losses(self.agent.policy, batch)
+                self.outer_optimizer.zero_grad()
+                outer_policy_loss.backward()
+                self.outer_optimizer.step()
+
+                outer_policy_loss_sum += outer_policy_loss
+                value_loss_sum += value_loss
+
+            inner_policy_loss_mean = inner_policy_loss_sum / (
+                self.inner_grad_iters * self.num_sample_tasks
+            )
+            outer_policy_loss_mean = outer_policy_loss_sum / (
+                self.inner_grad_iters * self.num_sample_tasks
+            )
+            value_loss_mean = value_loss_sum / (
+                self.inner_grad_iters * self.num_sample_tasks + self.outer_grad_iters
+            )
+
+            log_values = dict(
+                inner_policy_loss=inner_policy_loss_mean.item(),
+                outer_policy_loss=outer_policy_loss_mean.item(),
+                value_loss=value_loss_mean.item(),
+            )
 
             # Evaluate on test tasks
-            self.meta_test()
-        return NotImplementedError
+            self.meta_test(iteration, total_start_time, start_time, log_values)
 
-    def meta_test(self):
+    # pylint: disable=too-many-locals
+    def meta_test(self, iteration, total_start_time, start_time, log_values):
         """MAML meta-testing"""
+        test_results = {}
+        return_before_grad = 0
+        return_after_grad = 0
+        run_cost_before_grad = np.zeros(self.max_step)
+        run_cost_after_grad = np.zeros(self.max_step)
+
         for index in self.test_tasks:
             self.env.reset_task(index)
             self.agent.policy.is_deterministic = True
-        return NotImplementedError
+
+            # Branch policy network and its optimizer by Higher
+            with higher.innerloop_ctx(
+                self.agent.policy,
+                self.inner_optimizer_base,
+                copy_initial_weights=False,
+            ) as (inner_policy, inner_optimizer_branch):
+
+                inner_policy.is_deterministic = False
+                # Adapt meta-policy to each task with n-steps grandients
+                for _ in range(self.inner_grad_iters):
+                    # Sample trajectory with inner policy
+                    trajs = self.sampler.obtain_trajs(
+                        inner_policy,
+                        max_samples=self.train_samples,
+                        max_step=self.max_step,
+                    )
+                    self.inner_buffer.add_trajs(trajs)
+                    batch = self.inner_buffer.get_samples()
+                    # Inner update
+                    ppo_loss = self.agent.compute_losses(inner_policy, batch)
+                    inner_optimizer_branch.step(ppo_loss)
+
+                # Sample trajectory with adapted policy
+                trajs = self.sampler.obtain_trajs(
+                    inner_policy,
+                    max_samples=self.train_samples,
+                    max_step=self.max_step,
+                )
+
+                return_before_grad += sum(trajs[0]["rewards"])[0]
+                return_after_grad += sum(trajs[1]["rewards"])[0]
+                if self.env_name == "cheetah-vel":
+                    for i in range(self.max_step):
+                        run_cost_before_grad[i] += trajs[0]["infos"][i]
+                        run_cost_after_grad[i] += trajs[1]["infos"][i]
+
+        # Collect meta-test results
+        test_results["return_before_grad"] = return_before_grad / len(self.test_tasks)
+        test_results["return_after_grad"] = return_after_grad / len(self.test_tasks)
+        if self.env_name == "cheetah-vel":
+            test_results["run_cost_before_grad"] = run_cost_before_grad / len(self.test_tasks)
+            test_results["run_cost_after_grad"] = run_cost_after_grad / len(self.test_tasks)
+            test_results["total_run_cost_before_grad"] = sum(test_results["run_cost_before_grad"])
+            test_results["total_run_cost_after_grad"] = sum(test_results["run_cost_after_grad"])
+        test_results["inner_policy_loss"] = log_values["inner_policy_loss"]
+        test_results["outer_policy_loss"] = log_values["outer_policy_loss"]
+        test_results["value_loss"] = log_values["value_loss"]
+        test_results["total_time"] = time.time() - total_start_time
+        test_results["time_per_iter"] = time.time() - start_time
+
+        # Tensorboard
+        self.writer.add_scalar("test/return_before_grad", test_results["return_before_grad"], iteration)
+        self.writer.add_scalar("test/return_after_grad", test_results["return_after_grad"], iteration)
+        if self.env_name == "cheetah-vel":
+            self.writer.add_scalar(
+                "test/total_run_cost_before_grad",
+                test_results["total_run_cost_before_grad"],
+                iteration,
+            )
+            self.writer.add_scalar(
+                "test/total_run_cost_after_grad", test_results["total_run_cost_after_grad"], iteration
+            )
+            for step in range(len(test_results["run_cost_before_grad"])):
+                self.writer.add_scalar(
+                    "run_cost_before_grad/iteration_" + str(iteration),
+                    test_results["run_cost_before_grad"][step],
+                    step,
+                )
+                self.writer.add_scalar(
+                    "run_cost_after_grad/iteration_" + str(iteration),
+                    test_results["run_cost_after_grad"][step],
+                    step,
+                )
+        self.writer.add_scalar("train/inner_policy_loss", test_results["inner_policy_loss"], iteration)
+        self.writer.add_scalar("train/outer_policy_loss", test_results["outer_policy_loss"], iteration)
+        self.writer.add_scalar("train/value_loss", test_results["value_loss"], iteration)
+        self.writer.add_scalar("time/total_time", test_results["total_time"], iteration)
+        self.writer.add_scalar("time/time_per_iter", test_results["time_per_iter"], iteration)
+
+        # Logging
+        print(
+            f"--------------------------------------- \n"
+            f'return: {round(test_results["return_after_grad"], 2)} \n'
+            f'inner_policy_loss: {round(test_results["inner_policy_loss"], 2)} \n'
+            f'outer_policy_loss: {round(test_results["outer_policy_loss"], 2)} \n'
+            f'value_loss: {round(test_results["value_loss"], 2)} \n'
+            f'time_per_iter: {round(test_results["time_per_iter"], 2)} \n'
+            f'total_time: {round(test_results["total_time"], 2)} \n'
+            f"--------------------------------------- \n"
+        )
+
+        # Save the trained model
+        # TBU

--- a/src/maml/algorithm/meta_learner.py
+++ b/src/maml/algorithm/meta_learner.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
-from src.maml.algorithm.buffer import Buffer
+from src.maml.algorithm.buffer import Buffer, MultiBuffer
 from src.maml.algorithm.sampler import Sampler
 
 
@@ -40,14 +40,13 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
         self.train_tasks = train_tasks
         self.test_tasks = test_tasks
 
-        self.train_iters = config["train_iters"]
+        self.num_iterations = config["num_iterations"]
         self.num_sample_tasks = config["num_sample_tasks"]
-        self.train_samples = config["train_samples"]
-        self.max_step = config["max_step"]
-        self.test_samples = config["test_samples"]
+        self.num_samples = config["num_samples"]
+        self.max_steps = config["max_steps"]
 
-        self.inner_grad_iters = config["inner_grad_iters"]
-        self.outer_grad_iters = config["outer_grad_iters"]
+        self.num_adapt_epochs = config["num_adapt_epochs"]
+        self.num_maml_epochs = config["num_maml_epochs"]
 
         self.sampler = Sampler(
             env=env,
@@ -56,20 +55,27 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
             device=device,
         )
 
-        self.inner_buffer = Buffer(
+        self.train_inner_buffer = MultiBuffer(
             observ_dim=observ_dim,
             action_dim=action_dim,
-            max_size=self.train_samples * self.inner_grad_iters,
-            device=device,
-        )
-        self.outer_buffer = Buffer(
-            observ_dim=observ_dim,
-            action_dim=action_dim,
-            max_size=self.train_samples * self.inner_grad_iters * self.num_sample_tasks,
+            num_buffers=self.num_sample_tasks * self.num_adapt_epochs,
+            max_size=self.num_samples,
             device=device,
         )
 
-        self.inner_optimizer_base = torch.optim.SGD(
+        self.train_outer_buffer = MultiBuffer(
+            observ_dim=observ_dim,
+            action_dim=action_dim,
+            num_buffers=self.num_sample_tasks,
+            max_size=self.num_samples,
+            device=device,
+        )
+
+        self.test_buffer = Buffer(
+            observ_dim=observ_dim, action_dim=action_dim, max_size=self.num_samples, device=device
+        )
+
+        self.inner_optimizer = torch.optim.SGD(
             list(self.agent.model.parameters()),
             lr=config["inner_learning_rate"],
         )
@@ -93,87 +99,93 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
     def meta_train(self):
         """MAML meta-training"""
         total_start_time = time.time()
-        for iteration in range(self.train_iters):
+        for iteration in range(self.num_iterations):
             start_time = time.time()
-            inner_policy_loss_sum = 0
-            inner_vf_loss_sum = 0
-            outer_policy_loss_sum = 0
-            outer_vf_loss_sum = 0
+            total_loss_sum = 0
+            policy_loss_sum = 0
+            value_loss_sum = 0
 
             print(f"=============== Iteration {iteration} ===============")
             # Sample tasks randomly from train tasks distribution.
-            for i in range(self.num_sample_tasks):
-                index = np.random.randint(len(self.train_tasks))
-                self.env.reset_task(index)
-                self.agent.model.policy.is_deterministic = False
-                print(f"[{i+1}/{self.num_sample_tasks}] collecting inner-loop losses")
+            indices = np.random.randint(len(self.train_tasks), size=self.num_sample_tasks)
 
-                # Branch policy network and its optimizer by Higher
-                with higher.innerloop_ctx(
-                    self.agent.model,
-                    self.inner_optimizer_base,
-                    copy_initial_weights=False,
-                ) as (inner_model, inner_optimizer_branch):
+            for ppo_step in range(self.num_maml_epochs):
 
-                    inner_model.policy.is_deterministic = False
-                    # Adapt meta-policy to each task with n-steps grandients
-                    for _ in range(self.inner_grad_iters):
-                        # Sample trajectory with inner policy
-                        trajs = self.sampler.obtain_trajs(
-                            inner_model,
-                            max_samples=self.train_samples,
-                            max_step=self.max_step,
-                        )
-                        self.inner_buffer.add_trajs(trajs)
-
-                        # Inner update
-                        batch = self.inner_buffer.get_samples()
-                        total_loss, inner_policy_loss, inner_vf_loss = self.agent.compute_losses(
-                            inner_model, batch
-                        )
-                        inner_optimizer_branch.step(total_loss)
-
-                        inner_policy_loss_sum += inner_policy_loss
-                        inner_vf_loss_sum += inner_vf_loss
-
-                    inner_model.policy.is_deterministic = False
-                    # Sample trajectory with adapted policy
-                    trajs = self.sampler.obtain_trajs(
-                        inner_model,
-                        max_samples=self.train_samples,
-                        max_step=self.max_step,
-                    )
-                    self.outer_buffer.add_trajs(trajs)
-
-            # Meta update
-            print("Meta-updating outer-loop policy")
-            batch = self.outer_buffer.get_samples()
-            for _ in range(self.outer_grad_iters):
-                meta_loss, outer_policy_loss, outer_vf_loss = self.agent.compute_losses(
-                    self.agent.model, batch
+                print(
+                    f"[{ppo_step+1}/{self.num_maml_epochs}] adapting inner-loop models to sampled tasks"
                 )
-
                 self.outer_optimizer.zero_grad()
-                meta_loss.backward()
+                for cur_task, index in enumerate(indices):
+                    self.env.reset_task(index)
+                    self.agent.model.policy.is_deterministic = False
+
+                    # Branch meta-models(poicy&value) and its optimizer by Higher
+                    with higher.innerloop_ctx(
+                        self.agent.model,
+                        self.inner_optimizer,
+                        copy_initial_weights=False,
+                    ) as (inner_model, inner_optimizer_branch):
+
+                        # Adapt meta-models to each task with n-steps grandients
+                        inner_model.policy.is_deterministic = False
+                        for cur_adapt in range(self.num_adapt_epochs):
+                            # Sample pre-adapted trajectory with branched policy of the meta-policy
+                            if ppo_step == 0:
+                                pre_adapted_trajs = self.sampler.obtain_trajs(
+                                    inner_model,
+                                    max_samples=self.num_samples,
+                                    max_steps=self.max_steps,
+                                )
+                                self.train_inner_buffer.add_trajs(
+                                    cur_task, cur_adapt, pre_adapted_trajs
+                                )
+
+                            # Get post-adapted samples for the current task
+                            pre_adapted_batch = self.train_inner_buffer.get_samples(cur_task, cur_adapt)
+
+                            # Adapt the value function and the policy
+                            inner_total_loss, _, _ = self.agent.compute_losses(
+                                inner_model, pre_adapted_batch, clip_loss=False
+                            )
+                            inner_optimizer_branch.step(inner_total_loss)
+
+                        # Sample post-adapted trajectory with adapted policy
+                        if ppo_step == 0:
+                            inner_model.policy.is_deterministic = False
+                            post_adapted_trajs = self.sampler.obtain_trajs(
+                                inner_model,
+                                max_samples=self.num_samples,
+                                max_steps=self.max_steps,
+                            )
+                            self.train_outer_buffer.add_trajs(cur_task, 0, post_adapted_trajs)
+
+                        # Get post-adapted samples for the current task
+                        post_adapted_batch = self.train_outer_buffer.get_samples(cur_task, 0)
+
+                        # Compute value and policy loesses of the adapted models
+                        total_loss, policy_loss, value_loss = self.agent.compute_losses(
+                            inner_model, post_adapted_batch
+                        )
+                        total_loss.backward()
+
+                        total_loss_sum += total_loss.item() / self.num_sample_tasks
+                        policy_loss_sum += policy_loss.item() / self.num_sample_tasks
+                        value_loss_sum += value_loss.item() / self.num_sample_tasks
+
+                # Meta update
                 self.outer_optimizer.step()
 
-                outer_policy_loss_sum += outer_policy_loss
-                outer_vf_loss_sum += outer_vf_loss
+            self.train_inner_buffer.clear()
+            self.train_outer_buffer.clear()
 
-            inner_policy_loss_mean = inner_policy_loss_sum / (
-                self.inner_grad_iters * self.num_sample_tasks
-            )
-            inner_vf_loss_mean = inner_vf_loss_sum / (self.inner_grad_iters * self.num_sample_tasks)
-            outer_policy_loss_mean = outer_policy_loss_sum / (
-                self.outer_grad_iters * self.num_sample_tasks
-            )
-            outer_vf_loss_mean = outer_vf_loss_sum / (self.outer_grad_iters * self.num_sample_tasks)
+            total_loss_mean = total_loss_sum / self.num_maml_epochs
+            policy_loss_mean = policy_loss_sum / self.num_maml_epochs
+            value_loss_mean = value_loss_sum / self.num_maml_epochs
 
             log_values = dict(
-                inner_policy_loss=inner_policy_loss_mean.item(),
-                inner_vf_loss=inner_vf_loss_mean.item(),
-                outer_policy_loss=outer_policy_loss_mean.item(),
-                outer_vf_loss=outer_vf_loss_mean.item(),
+                total_loss=total_loss_mean,
+                policy_loss=policy_loss_mean,
+                value_loss=value_loss_mean,
             )
 
             # Evaluate on test tasks
@@ -186,53 +198,58 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
         test_results = {}
         return_before_grad = 0
         return_after_grad = 0
-        run_cost_before_grad = np.zeros(self.max_step)
-        run_cost_after_grad = np.zeros(self.max_step)
+        run_cost_before_grad = np.zeros(self.max_steps)
+        run_cost_after_grad = np.zeros(self.max_steps)
 
         for index in self.test_tasks:
-            trajs = []
+            test_trajs = []
             self.env.reset_task(index)
 
-            # Branch policy network and its optimizer by Higher
+            # Branch meta-models(poicy&value) and its optimizer by Higher
             with higher.innerloop_ctx(
                 self.agent.model,
-                self.inner_optimizer_base,
+                self.inner_optimizer,
                 copy_initial_weights=False,
             ) as (inner_model, inner_optimizer_branch):
 
+                # Adapt meta-models to each task with n-steps grandients
                 inner_model.policy.is_deterministic = False
-                # Adapt meta-policy to each task with n-steps grandients
-                for _ in range(self.inner_grad_iters):
-                    # Sample trajectory with inner policy
+                for _ in range(self.num_adapt_epochs):
+                    # Sample pre-adapted trajectory with branched policy of the meta-policy
                     pre_adapted_trajs = self.sampler.obtain_trajs(
                         inner_model,
-                        max_samples=self.test_samples,
-                        max_step=self.max_step,
+                        max_samples=self.num_samples,
+                        max_steps=self.max_steps,
                     )
-                    self.inner_buffer.add_trajs(pre_adapted_trajs)
-                    trajs.append(pre_adapted_trajs[0])
+                    self.test_buffer.add_trajs(pre_adapted_trajs)
+                    test_trajs.append(pre_adapted_trajs[0])
 
-                    # Inner update
-                    batch = self.inner_buffer.get_samples()
-                    total_loss, _, _ = self.agent.compute_losses(inner_model, batch)
-                    inner_optimizer_branch.step(total_loss)
+                    # Get pre-adapted samples for the current task
+                    batch = self.test_buffer.get_samples()
+                    self.test_buffer.clear()
 
+                    # Adapt the value function and the policy
+                    inner_total_loss, _, _ = self.agent.compute_losses(
+                        inner_model, batch, clip_loss=False
+                    )
+                    inner_optimizer_branch.step(inner_total_loss)
+
+                # Sample post-adapted trajectory with adapted policy
                 inner_model.policy.is_deterministic = True
-                # Sample trajectory with adapted policy
                 post_adapted_trajs = self.sampler.obtain_trajs(
                     inner_model,
-                    max_samples=self.test_samples,
-                    max_step=self.max_step,
+                    max_samples=self.num_samples,
+                    max_steps=self.max_steps,
                 )
-                trajs.append(post_adapted_trajs[0])
+                test_trajs.append(post_adapted_trajs[0])
 
-                return_before_grad += sum(trajs[0]["rewards"])[0]
-                return_after_grad += sum(trajs[-1]["rewards"])[0]
+                return_before_grad += sum(test_trajs[0]["rewards"])[0]
+                return_after_grad += sum(test_trajs[-1]["rewards"])[0]
 
                 if self.env_name == "cheetah-vel":
-                    for i in range(self.max_step):
-                        run_cost_before_grad[i] += trajs[0]["infos"][i]
-                        run_cost_after_grad[i] += trajs[-1]["infos"][i]
+                    for i in range(self.max_steps):
+                        run_cost_before_grad[i] += test_trajs[0]["infos"][i]
+                        run_cost_after_grad[i] += test_trajs[-1]["infos"][i]
 
         # Collect meta-test results
         test_results["return_before_grad"] = return_before_grad / len(self.test_tasks)
@@ -242,10 +259,9 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
             test_results["run_cost_after_grad"] = run_cost_after_grad / len(self.test_tasks)
             test_results["total_run_cost_before_grad"] = sum(test_results["run_cost_before_grad"])
             test_results["total_run_cost_after_grad"] = sum(test_results["run_cost_after_grad"])
-        test_results["inner_policy_loss"] = log_values["inner_policy_loss"]
-        test_results["inner_vf_loss"] = log_values["inner_vf_loss"]
-        test_results["outer_policy_loss"] = log_values["outer_policy_loss"]
-        test_results["outer_vf_loss"] = log_values["outer_vf_loss"]
+        test_results["total_loss"] = log_values["total_loss"]
+        test_results["policy_loss"] = log_values["policy_loss"]
+        test_results["value_loss"] = log_values["value_loss"]
 
         test_results["total_time"] = time.time() - total_start_time
         test_results["time_per_iter"] = time.time() - start_time
@@ -273,10 +289,9 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
                     test_results["run_cost_after_grad"][step],
                     step,
                 )
-        self.writer.add_scalar("train/inner_policy_loss", test_results["inner_policy_loss"], iteration)
-        self.writer.add_scalar("train/inner_vf_loss", test_results["inner_vf_loss"], iteration)
-        self.writer.add_scalar("train/outer_policy_loss", test_results["outer_policy_loss"], iteration)
-        self.writer.add_scalar("train/outer_vf_loss", test_results["outer_vf_loss"], iteration)
+        self.writer.add_scalar("train/total_loss", test_results["total_loss"], iteration)
+        self.writer.add_scalar("train/policy_loss", test_results["policy_loss"], iteration)
+        self.writer.add_scalar("train/value_loss", test_results["value_loss"], iteration)
         self.writer.add_scalar("time/total_time", test_results["total_time"], iteration)
         self.writer.add_scalar("time/time_per_iter", test_results["time_per_iter"], iteration)
 
@@ -285,10 +300,9 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
             f"--------------------------------------- \n"
             f'return_before_grad: {round(test_results["return_before_grad"], 2)} \n'
             f'return_after_grad: {round(test_results["return_after_grad"], 2)} \n'
-            f'inner_policy_loss: {round(test_results["inner_policy_loss"], 2)} \n'
-            f'inner_vf_loss: {round(test_results["inner_vf_loss"], 2)} \n'
-            f'outer_policy_loss: {round(test_results["outer_policy_loss"], 2)} \n'
-            f'outer_vf_loss: {round(test_results["outer_vf_loss"], 2)} \n'
+            f'total_loss: {round(test_results["total_loss"], 2)} \n'
+            f'policy_loss: {round(test_results["policy_loss"], 2)} \n'
+            f'value_loss: {round(test_results["value_loss"], 2)} \n'
             f'time_per_iter: {round(test_results["time_per_iter"], 2)} \n'
             f'total_time: {round(test_results["total_time"], 2)} \n'
             f"--------------------------------------- \n"

--- a/src/maml/algorithm/meta_learner.py
+++ b/src/maml/algorithm/meta_learner.py
@@ -277,3 +277,4 @@ class MetaLearner:  # pylint: disable=too-many-instance-attributes
 
         # Save the trained model
         # TBU
+        # TEST

--- a/src/maml/algorithm/networks.py
+++ b/src/maml/algorithm/networks.py
@@ -16,7 +16,7 @@ class MLP(nn.Module):
         self,
         input_dim,
         output_dim,
-        hidden_dims,
+        hidden_dim,
         hidden_activation=F.relu,
         init_w=3e-3,
     ):
@@ -26,15 +26,17 @@ class MLP(nn.Module):
 
         # Set fully connected layers
         self.fc_layers = nn.ModuleList()
-        in_dim = input_dim
-        for i, hidden_dim in enumerate(hidden_dims):
-            fc_layer = nn.Linear(in_dim, hidden_dim)
-            in_dim = hidden_dim
+        self.hidden_layers = [hidden_dim] * 2
+        in_layer = input_dim
+
+        for i, hidden_layer in enumerate(self.hidden_layers):
+            fc_layer = nn.Linear(in_layer, hidden_layer)
+            in_layer = hidden_layer
             self.__setattr__("fc_layer{}".format(i), fc_layer)
             self.fc_layers.append(fc_layer)
 
         # Set the output layer
-        self.last_fc_layer = nn.Linear(in_dim, output_dim)
+        self.last_fc_layer = nn.Linear(in_layer, output_dim)
         self.last_fc_layer.weight.data.uniform_(-init_w, init_w)
         self.last_fc_layer.bias.data.uniform_(-init_w, init_w)
 
@@ -53,7 +55,7 @@ class GaussianPolicy(MLP):
         self,
         input_dim,
         output_dim,
-        hidden_dims,
+        hidden_dim,
         env_target,
         is_deterministic=False,
         init_w=1e-3,
@@ -61,7 +63,7 @@ class GaussianPolicy(MLP):
         super().__init__(
             input_dim=input_dim,
             output_dim=output_dim,
-            hidden_dims=hidden_dims,
+            hidden_dim=hidden_dim,
             init_w=init_w,
         )
 

--- a/src/maml/algorithm/networks.py
+++ b/src/maml/algorithm/networks.py
@@ -55,7 +55,7 @@ LOG_SIG_MIN = -20
 
 
 class TanhGaussianPolicy(MLP):
-    """Gaussian policy network class using MLP and tanh activation function"""
+    """Gaussian policy network class containing Value network"""
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -123,3 +123,30 @@ class TanhGaussianPolicy(MLP):
 
         action = torch.tanh(action)
         return action, log_prob
+
+
+class Model(nn.Module):
+    """Set of fully connected networks containing Policy and Value function"""
+
+    def __init__(
+        self,
+        observ_dim,
+        action_dim,
+        hidden_dim,
+    ):
+        super().__init__()
+
+        self.policy = TanhGaussianPolicy(
+            input_dim=observ_dim,
+            output_dim=action_dim,
+            hidden_dim=hidden_dim,
+        )
+        self.vf = MLP(
+            input_dim=observ_dim,
+            output_dim=1,
+            hidden_dim=hidden_dim,
+        )
+
+    def forward(self, obs):
+        """Infer policy network"""
+        return self.policy(obs)

--- a/src/maml/algorithm/networks.py
+++ b/src/maml/algorithm/networks.py
@@ -22,6 +22,8 @@ class MLP(nn.Module):
     ):
         super().__init__()
 
+        self.input_dim = input_dim
+        self.output_dim = output_dim
         self.hidden_activation = hidden_activation
 
         # Set fully connected layers
@@ -36,7 +38,7 @@ class MLP(nn.Module):
             self.fc_layers.append(fc_layer)
 
         # Set the output layer
-        self.last_fc_layer = nn.Linear(in_layer, output_dim)
+        self.last_fc_layer = nn.Linear(hidden_dim, output_dim)
         self.last_fc_layer.weight.data.uniform_(-init_w, init_w)
         self.last_fc_layer.bias.data.uniform_(-init_w, init_w)
 
@@ -48,15 +50,18 @@ class MLP(nn.Module):
         return x
 
 
-class GaussianPolicy(MLP):
-    """Gaussian policy network class using MLP"""
+LOG_SIG_MAX = 2
+LOG_SIG_MIN = -20
+
+
+class TanhGaussianPolicy(MLP):
+    """Gaussian policy network class using MLP and tanh activation function"""
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
         input_dim,
         output_dim,
         hidden_dim,
-        env_target,
         is_deterministic=False,
         init_w=1e-3,
     ):
@@ -67,17 +72,20 @@ class GaussianPolicy(MLP):
             init_w=init_w,
         )
 
-        if env_target == "cheetah-dir":
-            self.log_std = -0.5 * np.ones(output_dim, dtype=np.float32)
-        elif env_target == "cheetah-vel":
-            self.log_std = -1.0 * np.ones(output_dim, dtype=np.float32)
-        self.log_std = torch.nn.Parameter(torch.Tensor(self.log_std))
         self.is_deterministic = is_deterministic
+        self.last_fc_log_std = nn.Linear(hidden_dim, output_dim)
+        self.last_fc_log_std.weight.data.uniform_(-init_w, init_w)
+        self.last_fc_log_std.bias.data.uniform_(-init_w, init_w)
 
     def get_normal_dist(self, x):
         """Get Gaussian distribtion"""
-        mean = super().forward(x)
-        std = torch.exp(self.log_std)
+        for fc_layer in self.fc_layers:
+            x = self.hidden_activation(fc_layer(x))
+
+        mean = self.last_fc_layer(x)
+        log_std = self.last_fc_log_std(x)
+        log_std = torch.clamp(log_std, LOG_SIG_MIN, LOG_SIG_MAX)
+        std = torch.exp(log_std)
         return Normal(mean, std), mean
 
     def get_log_prob(self, obs, action):
@@ -87,10 +95,31 @@ class GaussianPolicy(MLP):
 
     def forward(self, x):
         normal, mean = self.get_normal_dist(x)
+
         if self.is_deterministic:
-            action = mean
+            action = torch.tanh(mean)
             log_prob = None
         else:
-            action = normal.sample()
-            log_prob = normal.log_prob(action).sum(dim=-1)
+            # If reparameterize, use reparameterization trick (mean + std * N(0,1))
+            action = normal.rsample()
+
+            # Compute log prob from Gaussian,
+            # and then apply correction for Tanh squashing.
+            # NOTE: The correction formula is a little bit magic.
+            # To get an understanding of where it comes from,
+            # check out the original SAC paper
+            # (https://arxiv.org/abs/1801.01290) and look in appendix C.
+            # This is a more numerically-stable equivalent to Eq 21.
+            # Derivation:
+            #               log(1 - tanh(x)^2))
+            #               = log(sech(x)^2))
+            #               = 2 * log(sech(x)))
+            #               = 2 * log(2e^-x / (e^-2x + 1)))
+            #               = 2 * (log(2) - x - log(e^-2x + 1)))
+            #               = 2 * (log(2) - x - softplus(-2x)))
+            log_prob = normal.log_prob(action)
+            log_prob -= 2 * (np.log(2) - action - F.softplus(-2 * action))
+            log_prob = log_prob.sum(-1, keepdim=True)
+
+        action = torch.tanh(action)
         return action, log_prob

--- a/src/maml/algorithm/ppo.py
+++ b/src/maml/algorithm/ppo.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 import torch.optim as optim
 
-from src.maml.algorithm.networks import MLP, GaussianPolicy
+from src.maml.algorithm.networks import MLP, TanhGaussianPolicy
 
 
 class PPO:  # pylint: disable=too-many-instance-attributes
@@ -16,8 +16,7 @@ class PPO:  # pylint: disable=too-many-instance-attributes
         self,
         observ_dim,
         action_dim,
-        hidden_dims,
-        env_target,
+        hidden_dim,
         device,
         **config,
     ):
@@ -26,16 +25,15 @@ class PPO:  # pylint: disable=too-many-instance-attributes
         self.clip_param = config["clip_param"]
 
         # Instantiate networks
-        self.policy = GaussianPolicy(
+        self.policy = TanhGaussianPolicy(
             input_dim=observ_dim,
             output_dim=action_dim,
-            hidden_dims=hidden_dims,
-            env_target=env_target,
+            hidden_dim=hidden_dim,
         ).to(device)
         self.vf = MLP(
             input_dim=observ_dim,
             output_dim=1,
-            hidden_dims=hidden_dims,
+            hidden_dim=hidden_dim,
         ).to(device)
         self.vf_optimizer = optim.Adam(
             list(self.vf.parameters()),

--- a/src/maml/algorithm/ppo.py
+++ b/src/maml/algorithm/ppo.py
@@ -4,9 +4,8 @@ Proximal Policy Optimization algorithm implementation for training
 
 import torch
 import torch.nn.functional as F
-import torch.optim as optim
 
-from src.maml.algorithm.networks import MLP, TanhGaussianPolicy
+from src.maml.algorithm.networks import Model
 
 
 class PPO:  # pylint: disable=too-many-instance-attributes
@@ -25,35 +24,26 @@ class PPO:  # pylint: disable=too-many-instance-attributes
         self.clip_param = config["clip_param"]
 
         # Instantiate networks
-        self.policy = TanhGaussianPolicy(
-            input_dim=observ_dim,
-            output_dim=action_dim,
-            hidden_dim=hidden_dim,
+        self.model = Model(
+            observ_dim,
+            action_dim,
+            hidden_dim,
         ).to(device)
-        self.vf = MLP(
-            input_dim=observ_dim,
-            output_dim=1,
-            hidden_dim=hidden_dim,
-        ).to(device)
-        self.vf_optimizer = optim.Adam(
-            list(self.vf.parameters()),
-            lr=config["vf_learning_rate"],
-        )
 
     @staticmethod
-    def get_action(policy, obs, device):
+    def get_action(model, obs, device):
         """Get an action from the policy"""
-        action, log_prob = policy(torch.Tensor(obs).to(device))
+        action, log_prob = model(torch.Tensor(obs).to(device))
         if log_prob:
             log_prob = log_prob.detach().cpu().numpy()
         return action.detach().cpu().numpy(), log_prob
 
     def get_value(self, obs):
         """Get an value from the value network"""
-        value = self.vf(torch.Tensor(obs).to(self.device))
+        value = self.model.vf(torch.Tensor(obs).to(self.device))
         return value.detach().cpu().numpy()
 
-    def compute_losses(self, policy, batch):
+    def compute_losses(self, model, batch):
         """Compute loesses according to method of PPO algorithm"""
         obs_batch = batch["obs"]
         action_batch = batch["actions"]
@@ -61,18 +51,20 @@ class PPO:  # pylint: disable=too-many-instance-attributes
         advant_batch = batch["advants"]
         log_prob_batch = batch["log_probs"]
 
-        # Update Value function
-        value_batch = self.vf(obs_batch)
+        # Compute Value function loss
+        value_batch = self.model.vf(obs_batch)
         value_loss = F.mse_loss(value_batch, return_batch)
 
-        self.vf_optimizer.zero_grad()
-        value_loss.backward()
-        self.vf_optimizer.step()
-
         # Compute Policy loss
-        new_log_prob_batch = policy.get_log_prob(obs_batch, action_batch)
+        new_log_prob_batch = model.policy.get_log_prob(obs_batch, action_batch)
         ratio = torch.exp(new_log_prob_batch - log_prob_batch)
 
         policy_loss = ratio * advant_batch
         clipped_loss = torch.clamp(ratio, 1 - self.clip_param, 1 + self.clip_param) * advant_batch
-        return -torch.min(policy_loss, clipped_loss).mean(), value_loss
+
+        policy_loss = -torch.min(policy_loss, clipped_loss).mean()
+
+        # Total loss
+        total_loss = policy_loss + 0.5 * value_loss
+
+        return total_loss, policy_loss, value_loss

--- a/src/maml/algorithm/ppo.py
+++ b/src/maml/algorithm/ppo.py
@@ -37,7 +37,6 @@ class PPO:  # pylint: disable=too-many-instance-attributes
             output_dim=1,
             hidden_dims=hidden_dims,
         ).to(device)
-        # self.vf.to(device)
         self.vf_optimizer = optim.Adam(
             list(self.vf.parameters()),
             lr=config["vf_learning_rate"],

--- a/src/maml/algorithm/ppo.py
+++ b/src/maml/algorithm/ppo.py
@@ -26,6 +26,7 @@ class PPO:  # pylint: disable=too-many-instance-attributes
         self.gamma = gamma
         self.lamda = lamda
         self.clip_param = config["clip_param"]
+        self.vf_clip_param = config["vf_clip_param"]
 
         # Instantiate networks
         self.model = Model(
@@ -56,7 +57,7 @@ class PPO:  # pylint: disable=too-many-instance-attributes
         advant_batch = batch["advants"]
         log_prob_batch = batch["log_probs"]
 
-        # Compute Value function loss
+        # Compute GAE Value function loss
         value_batch = self.model.vf(obs_batch)
         value_loss = F.mse_loss(value_batch, return_batch)
 

--- a/src/maml/algorithm/ppo.py
+++ b/src/maml/algorithm/ppo.py
@@ -3,9 +3,9 @@ Proximal Policy Optimization algorithm implementation for training
 """
 
 import torch
-import torch.nn.functional as F
 
-from src.maml.algorithm.networks import Model
+from src.maml.algorithm.buffer import Buffer
+from src.maml.algorithm.networks import LinearValue, TanhGaussianPolicy
 
 
 class PPO:  # pylint: disable=too-many-instance-attributes
@@ -28,52 +28,57 @@ class PPO:  # pylint: disable=too-many-instance-attributes
         self.clip_param = config["clip_param"]
         self.vf_clip_param = config["vf_clip_param"]
 
-        # Instantiate networks
-        self.model = Model(
-            observ_dim,
-            action_dim,
-            hidden_dim,
+        self.policy = TanhGaussianPolicy(
+            input_dim=observ_dim, output_dim=action_dim, hidden_dim=hidden_dim
+        ).to(device)
+
+        self.baseline = LinearValue(
+            input_dim=observ_dim,
         ).to(device)
 
     @staticmethod
-    def get_action(model, obs, device):
+    def get_action(policy, obs, device):
         """Get an action from the policy"""
-        action, log_prob = model(torch.Tensor(obs).to(device))
+        action, log_prob = policy(torch.Tensor(obs).to(device))
         if log_prob:
             log_prob = log_prob.detach().cpu().numpy()
         return action.detach().cpu().numpy(), log_prob
 
     def get_value(self, obs):
         """Get an value from the value network"""
-        value = self.model.vf(torch.Tensor(obs).to(self.device))
+        value = self.baseline(torch.Tensor(obs).to(self.device))
         return value.detach().cpu().numpy()
 
     # pylint: disable=too-many-locals
-    def compute_losses(self, model, batch, clip_loss=True):
-        """Compute model losses according to PPO algorithm"""
+    def compute_losses(self, policy, batch, a2c_loss=False, clip_loss=True):
+        """Compute policy losses according to PPO algorithm"""
         obs_batch = batch["obs"]
         action_batch = batch["actions"]
         return_batch = batch["returns"]
-        advant_batch = batch["advants"]
+        reward_batch = batch["rewards"]
+        done_batch = batch["dones"]
         log_prob_batch = batch["log_probs"]
 
-        # Compute GAE Value function loss
-        value_batch = self.model.vf(obs_batch)
-        value_loss = F.mse_loss(value_batch, return_batch)
+        # Compute advantage with standard linear feature baseline (Daun el al. 2016)
+        self.baseline.fit(obs_batch, return_batch)
+        value_batch = self.baseline(obs_batch).detach()
+        advant_batch = Buffer.compute_gae(reward_batch, done_batch, value_batch).to(self.device)
 
         # Compute Policy loss
-        new_log_prob_batch = model.policy.get_log_prob(obs_batch, action_batch)
-        ratio = torch.exp(new_log_prob_batch - log_prob_batch)
-
-        surr_loss = ratio * advant_batch
-        if clip_loss:
-            clipped_loss = torch.clamp(ratio, 1 - self.clip_param, 1 + self.clip_param) * advant_batch
-            surr_loss = torch.min(surr_loss, clipped_loss).mean()
+        new_log_prob_batch = policy.get_log_prob(obs_batch, action_batch)
+        if a2c_loss:
+            policy_loss = new_log_prob_batch * advant_batch
+            policy_loss = -policy_loss.mean()
         else:
-            surr_loss = surr_loss.mean()
-
-        # Total loss
-        total_loss = -surr_loss + 0.5 * value_loss
+            ratio = torch.exp(new_log_prob_batch - log_prob_batch)
+            surr_loss = ratio * advant_batch
+            if clip_loss:
+                clipped_loss = (
+                    torch.clamp(ratio, 1 - self.clip_param, 1 + self.clip_param) * advant_batch
+                )
+                policy_loss = -torch.min(surr_loss, clipped_loss).mean()
+            else:
+                policy_loss = -surr_loss.mean()
 
         # print(policy_loss)
-        return total_loss, surr_loss, value_loss
+        return policy_loss

--- a/src/maml/algorithm/sampler.py
+++ b/src/maml/algorithm/sampler.py
@@ -22,23 +22,23 @@ class Sampler:
         self.action_dim = action_dim
         self.device = device
 
-    def obtain_trajs(self, model, max_samples, max_step, use_rendering=False):
+    def obtain_trajs(self, model, max_samples, max_steps, use_rendering=False):
         """Obtain samples up to the number of maximum samples"""
         self.model = model
         trajs = []
         cur_samples = 0
 
         while cur_samples < max_samples:
-            if max_step > max_samples - cur_samples:
-                max_step = max_samples - cur_samples
-            traj = self.rollout(max_step=max_step, use_rendering=use_rendering)
+            if max_steps > max_samples - cur_samples:
+                max_steps = max_samples - cur_samples
+            traj = self.rollout(max_steps=max_steps, use_rendering=use_rendering)
             trajs.append(traj)
 
             cur_samples += len(traj["cur_obs"])
         return trajs
 
     # pylint: disable=too-many-locals
-    def rollout(self, max_step, use_rendering=False):
+    def rollout(self, max_steps, use_rendering=False):
         """Rollout up to maximum trajectory length"""
         cur_obs = []
         actions = []
@@ -57,10 +57,9 @@ class Sampler:
         if use_rendering:
             self.env.render()
 
-        while cur_step < max_step:
+        while cur_step < max_steps:
             action, log_prob = self.agent.get_action(self.model, obs, self.device)
             value = self.agent.get_value(obs)
-
             next_obs, reward, done, info = self.env.step(action)
             reward = np.array(reward).reshape(-1)
             done = np.array(int(done)).reshape(-1)

--- a/src/maml/algorithm/sampler.py
+++ b/src/maml/algorithm/sampler.py
@@ -30,7 +30,7 @@ class Sampler:
 
         while cur_samples < max_samples:
             if max_step > max_samples - cur_samples:
-                max_step = max_samples - cur_samples + 1
+                max_step = max_samples - cur_samples
             traj = self.rollout(max_step=max_step, use_rendering=use_rendering)
             trajs.append(traj)
 

--- a/src/maml/algorithm/sampler.py
+++ b/src/maml/algorithm/sampler.py
@@ -3,7 +3,6 @@ Sample collection code through interaction between agent and environment
 """
 
 import numpy as np
-import torch
 
 
 class Sampler:
@@ -59,7 +58,7 @@ class Sampler:
             self.env.render()
 
         while cur_step < max_step:
-            action, log_prob = self.get_action(obs)
+            action, log_prob = self.agent.get_action(self.policy, obs, self.device)
             value = self.agent.get_value(obs)
 
             next_obs, reward, done, info = self.env.step(action)
@@ -89,10 +88,3 @@ class Sampler:
             values=np.array(values),
             log_probs=np.array(log_probs),
         )
-
-    def get_action(self, obs):
-        """Get an action from the policy"""
-        action, log_prob = self.policy(torch.Tensor(obs).to(self.device))
-        if log_prob:
-            log_prob = log_prob.detach().cpu().numpy()
-        return action.detach().cpu().numpy(), log_prob

--- a/src/maml/algorithm/sampler.py
+++ b/src/maml/algorithm/sampler.py
@@ -18,13 +18,13 @@ class Sampler:
 
         self.env = env
         self.agent = agent
-        self.model = agent.model
+        self.policy = agent.policy
         self.action_dim = action_dim
         self.device = device
 
-    def obtain_trajs(self, model, max_samples, max_steps, use_rendering=False):
+    def obtain_trajs(self, policy, max_samples, max_steps, use_rendering=False):
         """Obtain samples up to the number of maximum samples"""
-        self.model = model
+        self.policy = policy
         trajs = []
         cur_samples = 0
 
@@ -45,7 +45,6 @@ class Sampler:
         rewards = []
         dones = []
         infos = []
-        values = []
         log_probs = []
 
         cur_step = 0
@@ -58,8 +57,7 @@ class Sampler:
             self.env.render()
 
         while cur_step < max_steps:
-            action, log_prob = self.agent.get_action(self.model, obs, self.device)
-            value = self.agent.get_value(obs)
+            action, log_prob = self.agent.get_action(self.policy, obs, self.device)
             next_obs, reward, done, info = self.env.step(action)
             reward = np.array(reward).reshape(-1)
             done = np.array(int(done)).reshape(-1)
@@ -69,7 +67,6 @@ class Sampler:
             rewards.append(reward)
             dones.append(done)
             infos.append(info["run_cost"])
-            values.append(value.reshape(-1))
             if log_prob:
                 log_probs.append(log_prob.reshape(-1))
 
@@ -84,6 +81,5 @@ class Sampler:
             rewards=np.array(rewards),
             next_obs=np.vstack((cur_obs[1:], np.expand_dims(next_obs, 0))),
             dones=np.array(dones),
-            values=np.array(values),
             log_probs=np.array(log_probs),
         )

--- a/src/maml/algorithm/sampler.py
+++ b/src/maml/algorithm/sampler.py
@@ -18,13 +18,13 @@ class Sampler:
 
         self.env = env
         self.agent = agent
-        self.policy = agent.policy
+        self.model = agent.model
         self.action_dim = action_dim
         self.device = device
 
-    def obtain_trajs(self, policy, max_samples, max_step, use_rendering=False):
+    def obtain_trajs(self, model, max_samples, max_step, use_rendering=False):
         """Obtain samples up to the number of maximum samples"""
-        self.policy = policy
+        self.model = model
         trajs = []
         cur_samples = 0
 
@@ -58,7 +58,7 @@ class Sampler:
             self.env.render()
 
         while cur_step < max_step:
-            action, log_prob = self.agent.get_action(self.policy, obs, self.device)
+            action, log_prob = self.agent.get_action(self.model, obs, self.device)
             value = self.agent.get_value(obs)
 
             next_obs, reward, done, info = self.env.step(action)

--- a/src/maml/configs/dir_target_config.yaml
+++ b/src/maml/configs/dir_target_config.yaml
@@ -9,7 +9,7 @@ train_tasks: 2
 test_tasks: 2
 
 # Number of hidden units in neural networks
-hidden_dim: 100
+hidden_dim: 256
 
 # MAML setup
 # ----------
@@ -38,9 +38,5 @@ maml_params:
 ppo_params:
     # PPO clip parameter
     clip_param: 0.3
-    # coefficient of the value function 
-    vf_loss_coeff: 0.5
-    # Learning rate of value function
-    vf_learning_rate: 0.001
 
 

--- a/src/maml/configs/dir_target_config.yaml
+++ b/src/maml/configs/dir_target_config.yaml
@@ -9,27 +9,25 @@ train_tasks: 2
 test_tasks: 2
 
 # Number of hidden units in neural networks
-hidden_dim: 256
+hidden_dim: 64
 
 # MAML setup
 # ----------
 maml_params:
     # Number of training iterations
-    train_iters: 1000
+    num_iterations: 10000
     # Number of task samples for training
     num_sample_tasks: 5
     # Number of samples to train
-    train_samples: 200
-    # Maximum step for the environment
-    max_step: 200
-    # Number of samples to test
-    test_samples: 200
+    num_samples: 200
+    # Maximum steps for the environment
+    max_steps: 200
     # Number of inner adaptation iterations for the MAML algorithm
-    inner_grad_iters: 1
+    num_adapt_epochs: 1
     # Learning rate of inner adaptation
     inner_learning_rate: 0.1
     # Number of PPO iterations per each meta-update iteration
-    outer_grad_iters: 5
+    num_maml_epochs: 5
     # Learning rate of PPO losses
     outer_learning_rate: 0.001
 

--- a/src/maml/configs/dir_target_config.yaml
+++ b/src/maml/configs/dir_target_config.yaml
@@ -15,9 +15,9 @@ hidden_dim: 100
 # ----------
 maml_params:
     # Number of training iterations
-    train_iters: 200
+    train_iters: 1000
     # Number of task samples for training
-    num_sample_tasks: 2
+    num_sample_tasks: 5
     # Number of samples to train
     train_samples: 200
     # Maximum step for the environment
@@ -31,7 +31,7 @@ maml_params:
     # Number of PPO iterations per each meta-update iteration
     outer_grad_iters: 5
     # Learning rate of PPO losses
-    learning_rate: 0.001
+    outer_learning_rate: 0.001
 
 # PPO setup
 # ---------

--- a/src/maml/configs/dir_target_config.yaml
+++ b/src/maml/configs/dir_target_config.yaml
@@ -17,9 +17,9 @@ maml_params:
     # Number of training iterations
     num_iterations: 10000
     # Number of task samples for training
-    num_sample_tasks: 5
+    num_sample_tasks: 40
     # Number of samples to train
-    num_samples: 200
+    num_samples: 2000
     # Maximum steps for the environment
     max_steps: 200
     # Number of inner adaptation iterations for the MAML algorithm

--- a/src/maml/configs/dir_target_config.yaml
+++ b/src/maml/configs/dir_target_config.yaml
@@ -36,5 +36,7 @@ maml_params:
 ppo_params:
     # PPO clip parameter
     clip_param: 0.3
+    # vf clip parameter
+    vf_clip_param: 10
 
 

--- a/src/maml/configs/dir_target_config.yaml
+++ b/src/maml/configs/dir_target_config.yaml
@@ -9,7 +9,7 @@ train_tasks: 2
 test_tasks: 2
 
 # Number of hidden units in neural networks
-hidden_dims: [300, 300, 300]
+hidden_dim: 100
 
 # MAML setup
 # ----------
@@ -24,12 +24,12 @@ maml_params:
     max_step: 200
     # Number of samples to test
     test_samples: 200
-    # Number of inner adaptation steps for the MAML algorithm
-    inner_adaptation_steps: 1
+    # Number of inner adaptation iterations for the MAML algorithm
+    inner_grad_iters: 1
     # Learning rate of inner adaptation
     inner_learning_rate: 0.1
-    # Number of PPO steps per meta-update iteration
-    maml_optimizer_steps: 5
+    # Number of PPO iterations per each meta-update iteration
+    outer_grad_iters: 5
     # Learning rate of PPO losses
     learning_rate: 0.001
 

--- a/src/maml/configs/vel_target_config.yaml
+++ b/src/maml/configs/vel_target_config.yaml
@@ -9,7 +9,7 @@ train_tasks: 15
 test_tasks: 15
 
 # Number of hidden units in neural networks
-hidden_dims: [300, 300, 300]
+hidden_dim: 100
 
 maml_params:
     # Number of training iterations
@@ -22,12 +22,12 @@ maml_params:
     max_step: 200
     # Number of samples to test
     test_samples: 200
-    # Number of inner adaptation steps for the MAML algorithm
-    inner_adaptation_steps: 1
+    # Number of inner adaptation iterations for the MAML algorithm
+    inner_grad_iters: 1
     # Learning rate of inner adaptation
     inner_learning_rate: 0.1
-    # Number of PPO steps per meta-update iteration
-    maml_optimizer_steps: 5
+    # Number of PPO iterations per each meta-update iteration
+    outer_grad_iters: 5
     # Learning rate of PPO losses
     learning_rate: 0.001
 

--- a/src/maml/configs/vel_target_config.yaml
+++ b/src/maml/configs/vel_target_config.yaml
@@ -3,7 +3,7 @@
 # General setup
 # -------------
 # Number of tasks for meta-train
-train_tasks: 15
+train_tasks: 300
 
 # Number of tasks for meta-test
 test_tasks: 15
@@ -15,7 +15,7 @@ maml_params:
     # Number of training iterations
     num_iterations: 1000
     # Number of task samples for training
-    num_sample_tasks: 5
+    num_sample_tasks: 40
     # Number of samples to train
     num_samples: 200
     # Maximum steps for the environment

--- a/src/maml/configs/vel_target_config.yaml
+++ b/src/maml/configs/vel_target_config.yaml
@@ -9,7 +9,7 @@ train_tasks: 15
 test_tasks: 15
 
 # Number of hidden units in neural networks
-hidden_dim: 100
+hidden_dim: 256
 
 maml_params:
     # Number of training iterations
@@ -36,7 +36,3 @@ maml_params:
 ppo_params:
     # PPO clip parameter
     clip_param: 0.3
-    # coefficient of the value function 
-    vf_loss_coeff: 0.5
-    # Learning rate of value function
-    vf_learning_rate: 0.001

--- a/src/maml/configs/vel_target_config.yaml
+++ b/src/maml/configs/vel_target_config.yaml
@@ -13,7 +13,7 @@ hidden_dim: 100
 
 maml_params:
     # Number of training iterations
-    train_iters: 200
+    train_iters: 1000
     # Number of task samples for training
     num_sample_tasks: 5
     # Number of samples to train
@@ -29,7 +29,7 @@ maml_params:
     # Number of PPO iterations per each meta-update iteration
     outer_grad_iters: 5
     # Learning rate of PPO losses
-    learning_rate: 0.001
+    outer_learning_rate: 0.001
 
 # PPO setup
 # ---------

--- a/src/maml/configs/vel_target_config.yaml
+++ b/src/maml/configs/vel_target_config.yaml
@@ -13,21 +13,19 @@ hidden_dim: 256
 
 maml_params:
     # Number of training iterations
-    train_iters: 1000
+    num_iterations: 1000
     # Number of task samples for training
     num_sample_tasks: 5
     # Number of samples to train
-    train_samples: 200
-    # Maximum step for the environment
-    max_step: 200
-    # Number of samples to test
-    test_samples: 200
+    num_samples: 200
+    # Maximum steps for the environment
+    max_steps: 200
     # Number of inner adaptation iterations for the MAML algorithm
-    inner_grad_iters: 1
+    num_adapt_epochs: 1
     # Learning rate of inner adaptation
     inner_learning_rate: 0.1
     # Number of PPO iterations per each meta-update iteration
-    outer_grad_iters: 5
+    num_maml_epochs: 5
     # Learning rate of PPO losses
     outer_learning_rate: 0.001
 

--- a/src/maml/maml_trainer.py
+++ b/src/maml/maml_trainer.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
 
     observ_dim = env.observation_space.shape[0]
     action_dim = env.action_space.shape[0]
-    hidden_dim = env_target_config["hidden_dims"]
+    hidden_dim = env_target_config["hidden_dim"]
 
     device = (
         torch.device("cuda", index=experiment_config["gpu_index"])
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     agent = PPO(
         observ_dim=observ_dim,
         action_dim=action_dim,
-        hidden_dims=hidden_dim,
+        hidden_dim=hidden_dim,
         env_target=experiment_config["env_name"],
         device=device,
         **env_target_config["ppo_params"],

--- a/src/maml/maml_trainer.py
+++ b/src/maml/maml_trainer.py
@@ -48,7 +48,6 @@ if __name__ == "__main__":
         observ_dim=observ_dim,
         action_dim=action_dim,
         hidden_dim=hidden_dim,
-        env_target=experiment_config["env_name"],
         device=device,
         **env_target_config["ppo_params"],
     )

--- a/src/pearl/algorithm/networks.py
+++ b/src/pearl/algorithm/networks.py
@@ -187,7 +187,7 @@ class TanhGaussianPolicy(MLP):
         std = torch.exp(log_std)
 
         if self.is_deterministic:
-            action = torch.tanh(mean)
+            action = mean
             log_prob = None
         else:
             normal = Normal(mean, std)
@@ -212,5 +212,5 @@ class TanhGaussianPolicy(MLP):
             log_prob -= 2 * (np.log(2) - action - F.softplus(-2 * action))
             log_prob = log_prob.sum(-1, keepdim=True)
 
-            action = torch.tanh(action)
+        action = torch.tanh(action)
         return action, log_prob

--- a/src/pearl/algorithm/networks.py
+++ b/src/pearl/algorithm/networks.py
@@ -212,5 +212,5 @@ class TanhGaussianPolicy(MLP):
             log_prob -= 2 * (np.log(2) - action - F.softplus(-2 * action))
             log_prob = log_prob.sum(-1, keepdim=True)
 
-        action = torch.tanh(action)
+            action = torch.tanh(action)
         return action, log_prob


### PR DESCRIPTION
## PR Description

This PR is baseline for further experiment of MAML algorithm implementation.
- determine training structures to follow the learn2learn repo
- add meta-update
- add Linear-feature baseline
- compute advantage with newly fitted value
- change training configs to follow the official repo of MAML
- add multi-task buffer

## Related Issues

#31 #44 #47 

## Checklist

- [x] **Assignees** ran the `make format`.
- [x] **Assignees** ran the `make lint`.
- [x] **Assignees** checked the runnability of the code.
- [ ] **Reviewers** checked the runnability of the code.
- [ ] **Reviewers** checked plausibility of the training structure

## Experimental Results

TBU

## TODO

1. ~~Add Meta-training~~
2. ~~Add Meta-test~~
3. Experiment MAML with additional components for stabilization such as KL divergence and tanh output
4. Experiment MAML with different HP
6. Match code style and added functions with `RL^2` and `PEARL` 